### PR TITLE
Seed en las migraciones 'metodos_pago' y 'deportes' 

### DIFF
--- a/database/migrations/2025_03_05_121156_create_deportes_table.php
+++ b/database/migrations/2025_03_05_121156_create_deportes_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-
+use App\Models\Deporte;
 return new class extends Migration
 {
     /**
@@ -17,6 +17,32 @@ return new class extends Migration
             $table->integer('jugadores_por_equipo');
             $table->timestamps();
         });
+
+        Deporte::create([
+            'nombre' => 'Fútbol',
+            'jugadores_por_equipo' => 5,
+        ]);
+
+        Deporte::create([
+            'nombre' => 'Fútbol',
+            'jugadores_por_equipo' => 6,
+        ]);
+
+        Deporte::create([
+            'nombre' => 'Fútbol',
+            'jugadores_por_equipo' => 7,
+        ]);
+
+        Deporte::create([
+            'nombre' => 'Fútbol',
+            'jugadores_por_equipo' => 9,
+        ]);
+
+        Deporte::create([
+            'nombre' => 'Fútbol',
+            'jugadores_por_equipo' => 11,
+        ]);
+
     }
 
     /**

--- a/database/migrations/2025_03_21_090341_create_metodos_pago_table.php
+++ b/database/migrations/2025_03_21_090341_create_metodos_pago_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-
+use App\Models\MetodoPago;
 return new class extends Migration
 {
     /**
@@ -18,6 +18,24 @@ return new class extends Migration
             $table->boolean('activo')->default(true);
             $table->timestamps();
         });
+
+        MetodoPago::create([
+            'nombre' => 'Efectivo',
+            'descripcion' => 'Pago en efectivo',
+            'activo' => true,
+        ]);
+
+        MetodoPago::create([
+            'nombre' => 'Tarjeta de Crédito',
+            'descripcion' => 'Pago con tarjeta de crédito',
+            'activo' => true,
+        ]);
+
+        MetodoPago::create([
+            'nombre' => 'Transferencia Bancaria',
+            'descripcion' => 'Pago por transferencia bancaria',
+            'activo' => true,
+        ]);
     }
 
     /**

--- a/database/migrations/2025_03_27_110634_add_deporte_id_to_canchas_table.php
+++ b/database/migrations/2025_03_27_110634_add_deporte_id_to_canchas_table.php
@@ -1,0 +1,25 @@
+<?php
+// database/migrations/xxxx_xx_xx_xxxxxx_add_deporte_id_to_canchas_table.php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDeporteIdToCanchasTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('canchas', function (Blueprint $table) {
+            $table->unsignedBigInteger('deporte_id')->nullable()->after('id'); // Agregar la columna deporte_id
+            $table->foreign('deporte_id')->references('id')->on('deportes')->onDelete('cascade'); // Relación con deportes
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('canchas', function (Blueprint $table) {
+            $table->dropForeign(['deporte_id']);
+            $table->dropColumn('deporte_id');
+        });
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,62 +36,6 @@ class DatabaseSeeder extends Seeder
             'rol' => 'admin',
             'persona_id' => $persona->id,
         ]);
-
-        $persona = Persona::create([
-            'name' => 'moderador',
-            'dni' => '654321',
-            'telefono' => '1234567890',
-        ]);
-
-        CuentaCorriente::create([
-            'persona_id' => $persona->id,
-            'saldo' => 0,
-        ]);
-
-        User::factory()->create([
-            'email' => 'moderador@gmail.com',
-            'dni' => '654321',
-            'password' => bcrypt('password'),
-            'rol' => 'moderador',
-            'persona_id' => $persona->id,
-        ]);
-
-        $persona = Persona::create([
-            'name' => 'cliente',
-            'dni' => '87654321',
-            'telefono' => '1234567890',
-        ]);
-
-        CuentaCorriente::create([
-            'persona_id' => $persona->id,
-            'saldo' => 0,
-        ]);
-
-        User::factory()->create([
-            'email' => 'cliente@gmail.com',
-            'dni' => '87654321',
-            'password' => bcrypt('password'),
-            'rol' => 'cliente',
-            'persona_id' => $persona->id,
-        ]);
-
-        $persona = Persona::create([
-            'name' => 'Mora Gentil',
-            'dni' => '45396791',
-            'telefono' => '1234567890',
-        ]);
-
-        CuentaCorriente::create([
-            'persona_id' => $persona->id,
-            'saldo' => 0,
-        ]);
-
-        User::factory()->create([
-            'email' => 'moragentil@gmail.com',
-            'dni' => '45396791',
-            'password' => bcrypt('12345678'),
-            'rol' => 'cliente',
-            'persona_id' => $persona->id,
-        ]);
+        
     }
 }


### PR DESCRIPTION
Además, se crea una nueva migración para añadir la columna 'deporte_id' a la tabla 'canchas' con su respectiva relación. Se limpia el seeder de la base de datos eliminando datos innecesarios.