### PR TITLE
Metodo verificar pago

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,8 @@ Route::post('/mercadopago/webhook', [MercadoPagoWebhook::class, 'handleWebhook']
 Route::middleware(['auth:sanctum'])->group(function () {
 
     Route::post('/mercadopago/create-preference', [MercadoPagoController::class, 'createPreference']);
+    Route::post('/mercadopago/verify-payment', [MercadoPagoController::class, 'verifyPaymentStatus']);
+    
     
     Route::get('/canchas', [CanchaController::class, 'index']);
 


### PR DESCRIPTION
Para validar el estado de los pagos, incluyendo la verificación de datos y la respuesta adecuada según el resultado de la API de Mercado Pago. Se actualizan las rutas en 'api.php' para incluir esta nueva funcionalidad.